### PR TITLE
feat: add incremental update support to MCP analyze_repo

### DIFF
--- a/.qoderwork/skills/codewiki-wiki-generator/SKILL.md
+++ b/.qoderwork/skills/codewiki-wiki-generator/SKILL.md
@@ -100,6 +100,37 @@ cd CodeWiki-CN && pip install -e .
 
 调用 `close_session` → `{"session_id": "<session_id>"}` 释放内存。
 
+## 增量更新模式
+
+当仓库已生成过文档（`output_dir` 下存在 `metadata.json` 和 `module_tree.json`），`analyze_repo` 的返回结果会包含 `changes` 字段：
+
+```json
+{
+  "changes": {
+    "has_previous": true,
+    "no_changes": false,
+    "method": "git",
+    "changed_files": ["auth.py", "utils.py::hash_password"],
+    "affected_modules": ["认证模块"],
+    "cascade_modules": ["核心系统", "overview"]
+  }
+}
+```
+
+**变更检测策略**：优先使用 `git diff`（对比 commit SHA + 检查工作区未提交变更），非 git 仓库回退到对比文件修改时间。
+
+**增量更新流程**：
+
+1. 调用 `analyze_repo`，检查 `changes` 字段
+2. 如果 `no_changes: true`，告知用户文档已是最新，无需操作
+3. 如果 `no_changes: false`，**只更新 `affected_modules` 中列出的模块**：
+   - 用 `read_code_components` 读取变更组件的新源码
+   - 用 `edit_doc_file`（`str_replace`）局部修改对应文档，而非整篇重写
+4. 对 `cascade_modules` 中的父模块，读取已更新的子文档后同步刷新总览
+5. 最后更新 `overview.md`
+
+增量更新的粒度是**模块级**——一个模块内任一组件变更，该模块文档需要更新。相比全量生成，增量更新通常只需处理 1-3 个模块。
+
 ## 工具速查表
 
 | 工具 | 用途 |

--- a/IDE_DRIVEN_GUIDE.md
+++ b/IDE_DRIVEN_GUIDE.md
@@ -197,6 +197,85 @@ python -c "from codewiki.mcp.server import server; print('MCP Server OK')"
 
 ---
 
+## 增量更新
+
+### 原版 `--update` 的问题
+
+原始 CodeWiki CLI 提供了 `codewiki generate --update` 增量更新命令，但存在一个 bug：CLI 适配器创建 `DocumentationGenerator` 时未传入 `commit_id`，导致 `metadata.json` 中 `commit_id` 始终为 `null`。`_detect_changed_files()` 读到 `null` 后直接退化为全量生成。只有 Web 模式（`background_worker.py`）才正确写入了 `commit_id`，所以 CLI 下的 `--update` 实际上**永远等同于全量生成**。
+
+### MCP 增量更新方案
+
+我们在 `analyze_repo` 工具中重新实现了增量检测，并将其升级为双策略模式：
+
+```
+第一次调用 analyze_repo：
+  → 生成全量文档（changes 字段为 null）
+
+代码变更后再次调用 analyze_repo：
+  → 自动检测变更，返回 changes 字段
+  → AI Agent 只更新受影响的模块文档
+```
+
+**变更检测策略**（按优先级）：
+
+1. **Git 策略**：读取 `metadata.json` 中的 `commit_id`，与当前 HEAD 做 `git diff`，同时检查 `git status` 捕获未提交的变更
+2. **Mtime 策略**（非 git 仓库回退）：对比源文件修改时间与 `metadata.json` 中的 `timestamp`
+
+**返回结构**：
+
+```json
+{
+  "changes": {
+    "has_previous": true,
+    "no_changes": false,
+    "method": "git",
+    "changed_files": ["auth.py"],
+    "affected_modules": ["认证模块"],
+    "cascade_modules": ["核心系统", "overview"]
+  }
+}
+```
+
+- `affected_modules`：直接受影响的模块，需要更新文档
+- `cascade_modules`：间接受影响的父模块（子文档变了，总览也要刷新）和 `overview`
+
+### Agent 增量更新流程
+
+当 `analyze_repo` 返回 `changes` 且 `no_changes: false` 时，Agent 执行：
+
+```
+1. 只处理 affected_modules 中的模块：
+   ├── read_code_components → 读取变更组件源码
+   └── edit_doc_file(str_replace) → 局部修改文档（而非整篇重写）
+
+2. 处理 cascade_modules 中的父模块：
+   ├── view_repo_file → 读取已更新的子文档
+   └── edit_doc_file → 刷新总览部分
+
+3. 最后更新 overview.md
+```
+
+相比全量生成的 5 阶段流程，增量更新通常只需处理 1-3 个模块，耗时大幅缩短。
+
+### 实现细节
+
+核心代码在 `codewiki/mcp/tools/analysis.py`，新增 4 个函数（约 170 行）：
+
+| 函数 | 职责 |
+|------|------|
+| `_detect_changes()` | 主入口，协调 git/mtime 策略，调用模块映射 |
+| `_detect_via_git()` | Git 检测：commit diff + uncommitted changes |
+| `_detect_via_mtime()` | Mtime 回退：扫描源文件修改时间 |
+| `_find_affected_modules()` | 子串匹配变更文件 → 模块映射（复用原版逻辑） |
+
+`handle_analyze_repo()` 在构建完组件索引后调用 `_detect_changes()`，将结果附加到返回 JSON 的 `changes` 字段中。首次运行（无旧文档）时 `changes` 为 `null`，行为和之前完全一致。
+
+### 同时修复的架构问题
+
+改造过程中发现 `codewiki/__init__.py` 无条件 `import` 了 CLI 模块，导致启动 MCP Server 也必须安装 `keyring`、`click` 等 CLI 专属依赖。已将该 import 移除，MCP Server 现在可以轻量启动。CLI 入口（`__main__.py` 和 `pyproject.toml` 的 `codewiki = "codewiki.cli.main:cli"`）均直接从 `codewiki.cli.main` 导入，不受影响。
+
+---
+
 ## 输出结构
 
 生成的文档结构与原始 CodeWiki 一致：
@@ -249,3 +328,9 @@ A: 在对话中明确指定："Please generate the Wiki documentation in English
 
 **Q: 会话超时了怎么办？**
 A: 会话默认 2 小时超时。超时后重新调用 `analyze_repo` 即可创建新会话。
+
+**Q: 代码改了之后如何增量更新文档？**
+A: 直接对 AI Agent 说"更新 Wiki 文档"。Agent 调用 `analyze_repo` 时会自动检测变更，返回的 `changes` 字段会指出哪些模块受影响。Agent 只更新受影响的模块文档，而非全部重新生成。支持 git 仓库和非 git 仓库两种检测方式。
+
+**Q: 增量更新的粒度是什么？**
+A: 模块级。一个模块内任一组件的源文件变更，该模块的整篇文档会被标记为需要更新。同时其父模块的总览也会被标记（级联更新）。`overview.md` 在任何变更时都会刷新。

--- a/codewiki/__init__.py
+++ b/codewiki/__init__.py
@@ -1,14 +1,13 @@
 """
 CodeWiki: Transform codebases into comprehensive documentation using AI-powered analysis.
 
-This package provides a CLI tool for generating documentation from code repositories.
+This package provides a CLI tool for generating documentation from code repositories,
+and an MCP server for IDE-driven documentation generation.
 """
 
 __version__ = "1.0.1"
 __author__ = "CodeWiki Contributors"
 __license__ = "MIT"
 
-from codewiki.cli.main import cli
-
-__all__ = ["cli", "__version__"]
+__all__ = ["__version__"]
 

--- a/codewiki/mcp/server.py
+++ b/codewiki/mcp/server.py
@@ -72,7 +72,11 @@ def _fine_grained_tools() -> list[Tool]:
                 "using Tree-sitter AST parsing. Returns a component index and leaf nodes. "
                 "No LLM required. This is the entry point for the wiki generation pipeline. "
                 "After calling this, use get_prompt('cluster') to learn clustering rules, "
-                "then save_module_tree to persist your grouping."
+                "then save_module_tree to persist your grouping. "
+                "INCREMENTAL UPDATE: If docs already exist in output_dir (metadata.json + "
+                "module_tree.json), the response includes a 'changes' field showing which "
+                "files changed and which modules need updating. Use this to do targeted "
+                "edits instead of regenerating everything."
             ),
             inputSchema={
                 "type": "object",

--- a/codewiki/mcp/tools/analysis.py
+++ b/codewiki/mcp/tools/analysis.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from codewiki.mcp.session import SessionState, SessionStore
 
@@ -34,6 +35,207 @@ def _build_component_index(components: Dict[str, Any], max_items: int = 500) -> 
             "depends_on": list(getattr(node, "depends_on", []))[:20],
         })
     return index, len(components) > max_items
+
+
+# ---------------------------------------------------------------------------
+#  Incremental update: detect changes since last generation
+# ---------------------------------------------------------------------------
+
+def _detect_changes(
+    repo_path: Path,
+    output_dir: Path,
+) -> Optional[Dict[str, Any]]:
+    """Detect changes since last documentation generation.
+
+    Returns a changes dict with affected modules, or None if no previous
+    generation exists (first run).
+
+    Detection strategy:
+      1. Git-based: compare stored commit_id with current HEAD, plus check
+         uncommitted changes via ``git status``.
+      2. Fallback: compare file mtime with stored ``timestamp`` in metadata.
+    """
+    metadata_path = output_dir / "metadata.json"
+    module_tree_path = output_dir / "module_tree.json"
+
+    if not metadata_path.exists() or not module_tree_path.exists():
+        return None
+
+    try:
+        metadata = json.loads(metadata_path.read_text())
+        module_tree = json.loads(module_tree_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    # Try git-based detection first
+    changes = _detect_via_git(repo_path, metadata)
+
+    # Fallback to mtime-based detection
+    if changes is None:
+        changes = _detect_via_mtime(repo_path, metadata)
+
+    if changes is None:
+        return None
+
+    changed_files = changes["changed_files"]
+    if not changed_files:
+        return {
+            "has_previous": True,
+            "no_changes": True,
+            "method": changes.get("method", "unknown"),
+            "message": "No changes detected since last generation. Documentation is up to date.",
+        }
+
+    affected, cascade = _find_affected_modules(module_tree, changed_files)
+
+    return {
+        "has_previous": True,
+        "no_changes": False,
+        "method": changes.get("method", "unknown"),
+        "changed_files": changed_files[:50],
+        "affected_modules": sorted(affected),
+        "cascade_modules": sorted(cascade),
+        "hint": (
+            f"Only {len(affected)} module(s) need updating: {sorted(affected)}. "
+            f"Parent modules to refresh: {sorted(cascade)}. "
+            "Use edit_doc_file for targeted updates, write_doc_file for new modules."
+        ),
+    }
+
+
+def _detect_via_git(
+    repo_path: Path,
+    metadata: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Detect changes via git. Returns None if not in a git repo.
+
+    Checks both committed changes (diff against stored commit_id) and
+    uncommitted changes (``git status``).
+    """
+    try:
+        import git
+        repo = git.Repo(repo_path, search_parent_directories=True)
+    except Exception:
+        return None
+
+    prev_commit = metadata.get("generation_info", {}).get("commit_id")
+    try:
+        current_commit = repo.head.commit.hexsha
+    except Exception:
+        return None
+
+    changed: list[str] = []
+    method = "git"
+
+    # 1) Committed changes since last generation
+    if prev_commit and prev_commit != current_commit:
+        try:
+            diff_index = repo.commit(prev_commit).diff(current_commit)
+            seen: set[str] = set()
+            for diff in diff_index:
+                if diff.a_path and diff.a_path not in seen:
+                    changed.append(diff.a_path)
+                    seen.add(diff.a_path)
+                if diff.b_path and diff.b_path not in seen:
+                    changed.append(diff.b_path)
+                    seen.add(diff.b_path)
+        except Exception:
+            pass
+
+    # 2) Uncommitted changes (user may have edited but not committed)
+    try:
+        for item in repo.untracked_files:
+            if item not in changed:
+                changed.append(item)
+        for file_path in [d.a_path for d in repo.index.diff(None)]:
+            if file_path and file_path not in changed:
+                changed.append(file_path)
+    except Exception:
+        pass
+
+    return {"changed_files": changed, "method": method}
+
+
+def _detect_via_mtime(
+    repo_path: Path,
+    metadata: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Fallback: detect changed files by comparing mtime with generation timestamp."""
+    timestamp_str = metadata.get("generation_info", {}).get("timestamp")
+    if not timestamp_str:
+        return None
+
+    try:
+        from datetime import datetime
+        prev_time = datetime.fromisoformat(timestamp_str).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+    # Language extensions recognized by CodeWiki
+    source_extensions = {
+        ".py", ".java", ".js", ".jsx", ".ts", ".tsx",
+        ".c", ".h", ".cpp", ".hpp", ".cc", ".hh",
+        ".cs", ".kt", ".kts",
+    }
+
+    changed: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(repo_path):
+        # Skip hidden dirs and common non-source dirs
+        dirnames[:] = [
+            d for d in dirnames
+            if not d.startswith(".") and d not in ("node_modules", "__pycache__", "venv", ".venv")
+        ]
+        for filename in filenames:
+            filepath = Path(dirpath) / filename
+            if filepath.suffix.lower() not in source_extensions:
+                continue
+            try:
+                if filepath.stat().st_mtime > prev_time:
+                    rel_path = str(filepath.relative_to(repo_path))
+                    changed.append(rel_path)
+            except OSError:
+                continue
+
+    return {"changed_files": changed, "method": "mtime"}
+
+
+def _find_affected_modules(
+    module_tree: Dict[str, Any],
+    changed_files: List[str],
+) -> Tuple[set, set]:
+    """Map changed files to affected modules using module_tree.json.
+
+    Uses substring matching (same as the CLI ``_invalidate_affected_modules``).
+    Returns (affected_modules, cascade_parent_modules).
+    """
+    affected: set[str] = set()
+    cascade: set[str] = set()
+
+    def _walk(tree: Dict, parents: list[str] | None = None):
+        if parents is None:
+            parents = []
+        for mod_name, mod_info in tree.items():
+            components = mod_info.get("components", [])
+            hit = False
+            for comp in components:
+                if any(cf in comp or comp in cf for cf in changed_files):
+                    hit = True
+                    break
+            if hit:
+                affected.add(mod_name)
+                cascade.update(parents)
+
+            children = mod_info.get("children", {})
+            if isinstance(children, dict) and children:
+                _walk(children, parents + [mod_name])
+
+    _walk(module_tree)
+
+    # overview.md depends on all child docs, always refresh if anything changed
+    if affected:
+        cascade.add("overview")
+
+    return affected, cascade
 
 
 def handle_analyze_repo(
@@ -92,6 +294,9 @@ def handle_analyze_repo(
         lang = getattr(node, "language", "unknown")
         languages[lang] = languages.get(lang, 0) + 1
 
+    # Incremental update: detect changes since last generation
+    changes = _detect_changes(repo_path, output_dir)
+
     result = {
         "session_id": session.session_id,
         "repo_name": repo_path.name,
@@ -103,10 +308,17 @@ def handle_analyze_repo(
         "leaf_nodes": leaf_nodes[:100],
         "component_index": index,
         "component_index_truncated": truncated,
+        "changes": changes,
         "hint": (
             "Use read_code_components(session_id, component_ids) to read source code. "
             "Use save_module_tree(session_id, module_tree) after clustering. "
             "Call get_prompt('cluster') for clustering rules."
         ),
     }
+    if changes and not changes.get("no_changes"):
+        result["hint"] = (
+            "Incremental update detected. Only update affected modules listed in "
+            "'changes.affected_modules'. Use edit_doc_file for targeted updates. "
+            "Refresh cascade parent modules in 'changes.cascade_modules'."
+        )
     return json.dumps(result, indent=2, ensure_ascii=False)


### PR DESCRIPTION
- Add _detect_changes() with git diff + mtime dual-strategy detection
- Add _find_affected_modules() to map changed files to affected modules
- analyze_repo now returns a 'changes' field with affected/cascade modules
- Decouple codewiki/__init__.py from CLI imports for lightweight MCP startup
- Update skill and IDE_DRIVEN_GUIDE.md with incremental update docs