### PR TITLE
fix: address PR review feedback from upstream

### DIFF
--- a/codewiki/mcp/tools/analysis.py
+++ b/codewiki/mcp/tools/analysis.py
@@ -132,7 +132,7 @@ def _detect_via_git(
         for item in repo.untracked_files:
             if item not in changed:
                 changed.append(item)
-        for file_path in [d.a_path for d in repo.index.diff(None)]:
+        for file_path in [d.a_path for d in repo.index.diff("HEAD")]:
             if file_path and file_path not in changed:
                 changed.append(file_path)
     except Exception:
@@ -176,7 +176,7 @@ def _detect_via_mtime(
                 continue
             try:
                 if filepath.stat().st_mtime > prev_time:
-                    rel_path = str(filepath.relative_to(repo_path))
+                    rel_path = filepath.relative_to(repo_path).as_posix()
                     changed.append(rel_path)
             except OSError:
                 continue
@@ -203,8 +203,16 @@ def _find_affected_modules(
             components = mod_info.get("components", [])
             hit = False
             for comp in components:
-                if any(cf in comp or comp in cf for cf in changed_files):
-                    hit = True
+                comp_file = comp.split("::")[0]
+                for cf in changed_files:
+                    if comp_file == cf or comp_file.endswith("/" + cf) or cf.endswith("/" + comp_file):
+                        hit = True
+                        break
+                    # Changed dir contains the component file, or vice versa
+                    if cf.startswith(comp_file + "/") or comp_file.startswith(cf + "/"):
+                        hit = True
+                        break
+                if hit:
                     break
             if hit:
                 affected.add(mod_name)

--- a/codewiki/mcp/tools/doc_writer.py
+++ b/codewiki/mcp/tools/doc_writer.py
@@ -172,7 +172,7 @@ async def handle_edit_doc_file(
         replacement_line = current_content.split(old_str)[0].count("\n")
         lines = new_content.split("\n")
         start = max(0, replacement_line - 4)
-        end = min(len(lines), replacement_line + new_str.count("\n") + 5)
+        end = min(len(lines), start + new_str.count("\n") + 9)
         snippet = "\n".join(f"{i + start + 1:6}\t{lines[i]}" for i in range(start, end))
 
     elif command == "insert":
@@ -189,7 +189,7 @@ async def handle_edit_doc_file(
         doc_path.write_text(new_content, encoding="utf-8")
 
         start = max(0, insert_line - 4)
-        end = min(len(lines), insert_line + len(new_str_lines) + 4)
+        end = min(len(lines), start + len(new_str_lines) + 8)
         snippet = "\n".join(f"{i + start + 1:6}\t{lines[i]}" for i in range(start, end))
 
     else:

--- a/codewiki/mcp/workspace.py
+++ b/codewiki/mcp/workspace.py
@@ -20,6 +20,7 @@ Directory layout (relative to ``repo_path``)::
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -38,8 +39,13 @@ def _safe_filename(component_id: str) -> str:
 
     Component IDs look like ``src/main.py::MyClass``.  We replace any
     character that is not a word char, hyphen, or dot with ``__``.
+    A short hash suffix is appended to prevent collisions when different
+    component IDs sanitize to the same string (e.g. ``src/a-b.py`` vs
+    ``src/a_b.py``).
     """
-    return re.sub(r"[^\w\-.]", "__", component_id) + ".src"
+    sanitized = re.sub(r"[^\w\-.]", "__", component_id)
+    hash_suffix = hashlib.sha1(component_id.encode()).hexdigest()[:8]
+    return f"{sanitized}_{hash_suffix}.src"
 
 
 class SessionWorkspace:

--- a/codewiki/src/be/utils.py
+++ b/codewiki/src/be/utils.py
@@ -152,9 +152,9 @@ def extract_mermaid_blocks(content: str) -> List[Tuple[int, str]]:
 _PYTHONMONKEY_BROKEN = sys.version_info >= (3, 12)
 
 # mermaid-py spawns a Node.js subprocess that can hang indefinitely (e.g. when
-# Node.js is missing or the mermaid CLI is misconfigured).  Default to
-# disabled; set MERMAID_VALIDATE=1 to enable.
-_MERMAID_PY_BROKEN = os.environ.get("MERMAID_VALIDATE", "0") != "1"
+# Node.js is missing or the mermaid CLI is misconfigured).  Enabled by default;
+# set MERMAID_VALIDATE=0 to disable.
+_MERMAID_PY_BROKEN = os.environ.get("MERMAID_VALIDATE", "1") == "0"
 _MERMAID_PY_PROBED = True  # Skip probing — rely on env var
 
 
@@ -240,7 +240,7 @@ async def validate_single_diagram(diagram_content: str, diagram_num: int, line_s
     core_error = await _try_pythonmonkey_parse(diagram_content)
     if core_error is None:
         if _MERMAID_PY_BROKEN:
-            return f"  Diagram {diagram_num}: validation skipped (set MERMAID_VALIDATE=1 to enable)"
+            return f"  Diagram {diagram_num}: validation skipped (mermaid-py unavailable; set MERMAID_VALIDATE=0 to suppress)"
         try:
             core_error = await asyncio.wait_for(
                 asyncio.to_thread(_parse_via_mermaid_py, diagram_content),


### PR DESCRIPTION
- Remove unrelated files (CodeWiki介绍.md, img/logo-banner.png)
- Replace fork-specific references (CodeWiki-CN) with upstream (CodeWiki) in IDE_DRIVEN_GUIDE.md and SKILL.md
- Fix off-by-start line number calculation in edit_doc_file snippet window
- Use .as_posix() for mtime path detection to fix Windows path separators
- Fix _find_affected_modules substring over-matching with path-based matching
- Use index.diff('HEAD') to capture staged changes (not just unstaged)
- Enable Mermaid validation by default to match documentation promises
- Add SHA1 hash suffix to _safe_filename to prevent component ID collisions